### PR TITLE
Add passthrough `serde` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,9 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -651,6 +654,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ opt-level = 1
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]
 opt-level = 3
+
+[features]
+# Allow enabling serde support for downstream crates
+serde = ["crossterm/serde"]


### PR DESCRIPTION
Currently, downstream crates are unable to serialize or deserialize anything from `crossterm`, even though it's implemented serde support. This change adds a feature `serde` that simply enables `crossterm/serde` for downstream crates that want it.