### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.8.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.7.1...v0.8.0) - 2025-04-26
+
+### Added
+
+- Add passthrough `serde` feature
+
+### Other
+
+- make ctrl+c handling optional
+- cargo fmt
+- cargo fix --edition
+- migration to bevy 0.16
+
 ## [0.7.1](https://github.com/cxreiff/bevy_ratatui/compare/v0.7.0...v0.7.1) - 2025-03-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bevy",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See the [demo example](examples/demo.rs) for the code and more information.
 
 | bevy  | bevy_ratatui |
 |-------|--------------|
+| 0.16  | 0.8          |
 | 0.15  | 0.7          |
 | 0.14  | 0.6          |
 | 0.13  | 0.5          |


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui` breaking changes

```text
--- failure function_marked_deprecated: function #[deprecated] added ---

Description:
A function is now #[deprecated]. Downstream crates will get a compiler warning when using this function.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_marked_deprecated.ron

Failed in:
  function bevy_ratatui::error::exit_on_error in /tmp/.tmpgiJcrb/bevy_ratatui/src/error.rs:75

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct EventPlugin in /tmp/.tmpgiJcrb/bevy_ratatui/src/event.rs:49
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.7.1...v0.8.0) - 2025-04-26

### Added

- Add passthrough `serde` feature

### Other

- make ctrl+c handling optional
- cargo fmt
- cargo fix --edition
- migration to bevy 0.16
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).