### PR TITLE
Make ctrl+c handling optional

### DIFF
--- a/src/ratatui.rs
+++ b/src/ratatui.rs
@@ -46,7 +46,7 @@ impl PluginGroup for RatatuiPlugins {
         let mut builder = PluginGroupBuilder::start::<Self>()
             .add(error::ErrorPlugin)
             .add(terminal::TerminalPlugin)
-            .add(event::EventPlugin);
+            .add(event::EventPlugin::default());
         if self.enable_kitty_protocol {
             builder = builder.add(kitty::KittyPlugin);
         }


### PR DESCRIPTION
Separated out `control + c` interrupt handler to a separate system that can be disabled by setting `EventPlugin::control_c_interrupt` to false.

This preserves the default of users being able to exit without closing their terminal window, while allowing cases where applications require other behavior when `control+c` is pressed.

Fixes #46.