### PR TITLE
fixed issue when bevy/bevy_winit feature enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "crossterm 0.29.0",
  "rand 0.9.1",
  "ratatui",
+ "smol_str",
  "tracing",
 ]
 
@@ -1988,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2049,15 +2050,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2565,18 +2566,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bitflags = "2.8.0"
 color-eyre = "0.6.3"
 crossterm = "0.29.0"
 ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
+smol_str = "0.2.2"
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/src/input_forwarding/keyboard.rs
+++ b/src/input_forwarding/keyboard.rs
@@ -11,6 +11,7 @@ use bevy::{
     prelude::*,
 };
 use crossterm::event::KeyModifiers;
+use smol_str::SmolStr;
 
 use crate::event::{InputSet, KeyEvent};
 
@@ -496,7 +497,14 @@ fn key_event_to_bevy(
     };
     let key_code = to_bevy_keycode(code);
     let logical_key = to_bevy_key(code);
-    let text = logical_key.as_ref().and_then(logical_key_to_text);
+
+    // Using `into()` here because a String or a SmolStr are required depending on the enabled bevy
+    // features.
+    #[warn(clippy::useless_conversion)]
+    let text = logical_key
+        .as_ref()
+        .and_then(logical_key_to_text)
+        .map(|s| s.into());
 
     key_code
         .zip(logical_key)
@@ -974,9 +982,9 @@ fn crossterm_modifier_to_bevy_key(
     result
 }
 
-fn logical_key_to_text(logical_key: &bevy::input::keyboard::Key) -> Option<String> {
+fn logical_key_to_text(logical_key: &bevy::input::keyboard::Key) -> Option<SmolStr> {
     if let bevy::input::keyboard::Key::Character(character) = logical_key {
-        Some(character.clone())
+        Some(SmolStr::new(character.clone()))
     } else {
         None
     }


### PR DESCRIPTION
Mistakenly removed smol-str because I thought it was no longer necessary, but it turned out it was necessary depending on which bevy features were enabled.

Bevy uses a String or a SmolStr based on whether the `bevy/bevy_winit` feature is enabled. This PR adds `smol_str` back and adds an `into()` call for coercing to the correct type in both scenarios.