### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.8.1](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.0...v0.8.1) - 2025-04-27
+
+### Fixed
+
+- fixed issue when bevy/bevy_winit feature enabled
+
 ## [0.8.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.7.1...v0.8.0) - 2025-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bevy",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.0...v0.8.1) - 2025-04-27

### Fixed

- fixed issue when bevy/bevy_winit feature enabled
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).