### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.8.2](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.1...v0.8.2) - 2025-04-27
+
+### Other
+
+- actually remove ctrl-c behavior from passthrough
+
 ## [0.8.1](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.0...v0.8.1) - 2025-04-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "bevy",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"


### PR DESCRIPTION


## 🤖 New release

* `bevy_ratatui`: 0.8.1 -> 0.8.2

Breaking change note removed as it refers to parameters in a bevy system (never called directly by downstream users).

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.1...v0.8.2) - 2025-04-27

### Other

- actually remove ctrl-c behavior from passthrough
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).