### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.9.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.3...v0.9.0) - 2025-05-13
+
+### Fixed
+
+- fixed workflows
+
+### Other
+
+- miscellaneous docs updates
+- public facing module structure
+- miscellaneous fixes for examples
+- refactored for encapsulation of context type
+- miscellaneous improvements and addressed comments
+- rename window feature from 'soft' to 'windowed'
+- integrate soft_ratatui for a windowed output mode
+
+### Removed
+
+- removed some cfg feature gates
+
 ## [0.8.3](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.2...v0.8.3) - 2025-04-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "bevy",
  "bitflags 2.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ There are also a handful of features relating to running Bevy in `no_std` mode.
 
 | bevy  | bevy_ratatui |
 |-------|--------------|
-| 0.16  | 0.8          |
+| 0.16  | 0.9          |
 | 0.15  | 0.7          |
 | 0.14  | 0.6          |
 | 0.13  | 0.5          |


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui`: 0.8.3 -> 0.9.0 (⚠ API breaking changes)

### ⚠ `bevy_ratatui` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum bevy_ratatui::input_forwarding::ReleaseKey, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/keyboard.rs:201
  enum bevy_ratatui::input_forwarding::EmulationPolicy, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/keyboard.rs:43

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function bevy_ratatui::kitty::disable_kitty_protocol, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/kitty.rs:60
  function bevy_ratatui::event::crossterm_event_system, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/event.rs:123
  function bevy_ratatui::terminal::cleanup_system, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/terminal.rs:40
  function bevy_ratatui::terminal::setup, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/terminal.rs:33
  function bevy_ratatui::error::setup, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/error.rs:39
  function bevy_ratatui::kitty::enable_kitty_protocol, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/kitty.rs:46
  function bevy_ratatui::error::exit_on_error, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/error.rs:75

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod bevy_ratatui::terminal, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/terminal.rs:1
  mod bevy_ratatui::input_forwarding, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct bevy_ratatui::input_forwarding::Capability, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/keyboard.rs:18
  struct bevy_ratatui::input_forwarding::KeyboardPlugin, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/keyboard.rs:76
  struct bevy_ratatui::input_forwarding::Emulate, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/keyboard.rs:302
  struct bevy_ratatui::terminal::TerminalPlugin, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/terminal.rs:23
  struct bevy_ratatui::mouse::MouseCaptureEnabled, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/mouse.rs:19
  struct bevy_ratatui::terminal::RatatuiContext, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/terminal.rs:66
  struct bevy_ratatui::input_forwarding::Detected, previously in file /tmp/.tmpFif6oK/bevy_ratatui/src/input_forwarding/keyboard.rs:72
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.0](https://github.com/cxreiff/bevy_ratatui/compare/v0.8.3...v0.9.0) - 2025-05-13

### Fixed

- fixed workflows

### Other

- miscellaneous docs updates
- public facing module structure
- miscellaneous fixes for examples
- refactored for encapsulation of context type
- miscellaneous improvements and addressed comments
- rename window feature from 'soft' to 'windowed'
- integrate soft_ratatui for a windowed output mode

### Removed

- removed some cfg feature gates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).