### PR TITLE
new feature for toggling crossterm context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ keywords = ["cli", "ratatui", "terminal", "tui", "bevy"]
 bevy = { version = "0.16", default-features = false }
 bitflags = "2.8.0"
 color-eyre = "0.6.3"
-crossterm = "0.29.0"
-ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
+crossterm = { version = "0.29.0", optional = true }
+ratatui = { version = "0.29.0", default-features = false }
 smol_str = "0.2.2"
 soft_ratatui = { version = "0.0.8", optional = true }
 tracing = "0.1.41"
@@ -23,6 +23,7 @@ tracing = "0.1.41"
 [dev-dependencies]
 rand = "0.9.0"
 bevy = { version = "0.16", default-features = false, features = ["bevy_state"] }
+ratatui = { version = "0.29.0", features = ["unstable-widget-ref"] }
 
 # Enable a small amount of optimization in debug mode
 [profile.dev]
@@ -33,7 +34,8 @@ opt-level = 1
 opt-level = 3
 
 [features]
-default = ["std", "async_executor"]
+default = ["std", "async_executor", "crossterm"]
+crossterm = ["dep:crossterm", "ratatui/crossterm"]
 windowed = ["dep:soft_ratatui", "bevy/default"]
 
 # Features for `std` platforms

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //! [examples]: https://github.com/cxreiff/bevy_ratatui/tree/main/examples
 
 mod context_trait;
+#[cfg(feature = "crossterm")]
 mod crossterm_context;
 mod ratatui_context;
 mod ratatui_plugin;
@@ -67,6 +68,7 @@ pub use ratatui_plugin::RatatuiPlugins;
 
 pub mod context {
     pub use super::context_trait::TerminalContext;
+    #[cfg(feature = "crossterm")]
     pub use super::crossterm_context::context::CrosstermContext;
     pub use super::ratatui_context::DefaultContext;
     pub use super::ratatui_plugin::ContextPlugin;
@@ -74,14 +76,17 @@ pub mod context {
     pub use super::windowed_context::context::WindowedContext;
 }
 
+#[cfg(feature = "crossterm")]
 pub mod cleanup {
     pub use super::crossterm_context::cleanup::CleanupPlugin;
 }
 
+#[cfg(feature = "crossterm")]
 pub mod error {
     pub use super::crossterm_context::error::ErrorPlugin;
 }
 
+#[cfg(feature = "crossterm")]
 pub mod event {
     pub use super::crossterm_context::event::{
         CrosstermEvent, EventPlugin, FocusEvent, InputSet, KeyEvent, MouseEvent, PasteEvent,
@@ -89,14 +94,17 @@ pub mod event {
     };
 }
 
+#[cfg(feature = "crossterm")]
 pub mod kitty {
     pub use super::crossterm_context::kitty::{KittyEnabled, KittyPlugin};
 }
 
+#[cfg(feature = "crossterm")]
 pub mod mouse {
     pub use super::crossterm_context::mouse::{MouseEnabled, MousePlugin};
 }
 
+#[cfg(feature = "crossterm")]
 pub mod translation {
     pub use super::crossterm_context::translation::*;
 }

--- a/src/ratatui_context.rs
+++ b/src/ratatui_context.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use super::context_trait::TerminalContext;
 
-#[cfg(not(feature = "windowed"))]
+#[cfg(all(feature = "crossterm", not(feature = "windowed")))]
 pub type DefaultContext = crate::context::CrosstermContext;
 
 #[cfg(feature = "windowed")]

--- a/src/windowed_context/plugin.rs
+++ b/src/windowed_context/plugin.rs
@@ -28,7 +28,7 @@ pub fn terminal_render_setup(
     softatui: ResMut<RatatuiContext>,
     mut images: ResMut<Assets<Image>>,
 ) -> Result {
-    commands.spawn(bevy::core_pipeline::core_2d::Camera2d);
+    commands.spawn(Camera2d);
     // Create an image that we are going to draw into
     let width = softatui.backend().get_pixmap_width() as u32;
     let height = softatui.backend().get_pixmap_height() as u32;


### PR DESCRIPTION
The dependency on crossterm causes issues with web targets, so by gating the crossterm dependency and crossterm-related code behind a "crossterm" feature and making it a default feature, we can ensure that the default functionality is unchanged but users have a way to remove the crossterm dependency if targeting the web, by removing default features.