### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.9.2](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.1...v0.9.2) - 2025-05-27
+
+### Other
+
+- remove direct dependency on crossterm
+
 ## [0.9.1](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.0...v0.9.1) - 2025-05-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,7 +965,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bevy",
  "bitflags 2.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"


### PR DESCRIPTION


## 🤖 New release

* `bevy_ratatui`: 0.9.1 -> 0.9.2

`crossterm` is no longer a direct dependency, so the `serde` feature was also removed (which only affected crossterm). For enabling serde on crossterm, use the features on crossterm directly.

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.2](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.1...v0.9.2) - 2025-05-27

### Other

- remove direct dependency on crossterm
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).