### PR TITLE
update soft_ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "az"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,7 +1209,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "cosmic-text 0.13.2",
+ "cosmic-text",
  "serde",
  "smallvec",
  "sys-locale",
@@ -1360,7 +1366,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
 ]
@@ -1767,30 +1773,7 @@ dependencies = [
  "fontdb",
  "log",
  "rangemap",
- "rustc-hash",
- "rustybuzz",
- "self_cell",
- "smol_str",
- "swash",
- "sys-locale",
- "ttf-parser 0.21.1",
- "unicode-bidi",
- "unicode-linebreak",
- "unicode-script",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "cosmic-text"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da46a9d5a8905cc538a4a5bceb6a4510de7a51049c5588c0114efce102bcbbe8"
-dependencies = [
- "bitflags 2.9.0",
- "fontdb",
- "log",
- "rangemap",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustybuzz",
  "self_cell",
  "smol_str",
@@ -2029,6 +2012,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-graphics"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0649998afacf6d575d126d83e68b78c0ab0e00ca2ac7e9b3db11b4cbe8274ef0"
+dependencies = [
+ "az",
+ "byteorder",
+ "embedded-graphics-core",
+ "float-cmp",
+ "micromath",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba9ecd261f991856250d2207f6d8376946cd9f412a2165d3b75bc87a0bc7a044"
+dependencies = [
+ "az",
+ "byteorder",
+]
+
+[[package]]
+name = "embedded-graphics-unicodefonts"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82ef1580d1bff3e89bd3e68069acb24910b66001aaab1738ce9de8d03d2ab1e"
+dependencies = [
+ "embedded-graphics",
+]
+
+[[package]]
 name = "encase"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2170,15 @@ checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.8",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2907,6 +2931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,7 +2988,7 @@ dependencies = [
  "indexmap",
  "log",
  "pp-rs",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "spirv",
  "strum",
  "termcolor",
@@ -2980,7 +3010,7 @@ dependencies = [
  "once_cell",
  "regex",
  "regex-syntax 0.8.5",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "thiserror 1.0.69",
  "tracing",
  "unicode-ident",
@@ -3890,6 +3920,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4095,12 +4131,14 @@ dependencies = [
 
 [[package]]
 name = "soft_ratatui"
-version = "0.0.8"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f86103b6d0ae58ba8be0939008b32d919ba6f504e7c46a14254dbe33452de8"
+checksum = "f1e6b1682745f3de31a0665b69dc25f286be1ad50f3570a9a0bc4f65a5694b67"
 dependencies = [
- "cosmic-text 0.14.2",
+ "embedded-graphics",
+ "embedded-graphics-unicodefonts",
  "ratatui",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -4719,7 +4757,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "raw-window-handle",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
  "wgpu-hal",
@@ -4762,7 +4800,7 @@ dependencies = [
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.12",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bitflags = "2.8.0"
 color-eyre = "0.6.3"
 ratatui = { version = "0.29.0", default-features = false }
 smol_str = "0.2.2"
-soft_ratatui = { version = "0.0.8", optional = true }
+soft_ratatui = { version = "0.1", optional = true }
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/src/windowed_context/context.rs
+++ b/src/windowed_context/context.rs
@@ -4,16 +4,18 @@ use bevy::prelude::*;
 
 use ratatui::Terminal;
 
-use soft_ratatui::SoftBackend;
-
 use crate::context::TerminalContext;
+use soft_ratatui::embedded_graphics_unicodefonts::{
+    mono_8x13_atlas, mono_8x13_bold_atlas, mono_8x13_italic_atlas,
+};
+use soft_ratatui::{EmbeddedGraphics, SoftBackend};
 
 use super::plugin::WindowedPlugin;
 
 /// Ratatui context that will set up a window and render the ratatui buffer using a 2D texture,
 /// instead of drawing to a terminal buffer.
 #[derive(Deref, DerefMut)]
-pub struct WindowedContext(Terminal<SoftBackend>);
+pub struct WindowedContext(Terminal<SoftBackend<EmbeddedGraphics>>);
 
 impl Debug for WindowedContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -21,9 +23,18 @@ impl Debug for WindowedContext {
     }
 }
 
-impl TerminalContext<SoftBackend> for WindowedContext {
+impl TerminalContext<SoftBackend<EmbeddedGraphics>> for WindowedContext {
     fn init() -> Result<Self> {
-        let backend = SoftBackend::new_with_system_fonts(15, 15, 16);
+        let font_regular = mono_8x13_atlas();
+        let font_italic = mono_8x13_italic_atlas();
+        let font_bold = mono_8x13_bold_atlas();
+        let backend = SoftBackend::<EmbeddedGraphics>::new(
+            100,
+            50,
+            font_regular,
+            Some(font_bold),
+            Some(font_italic),
+        );
         let terminal = Terminal::new(backend)?;
         Ok(Self(terminal))
     }


### PR DESCRIPTION
soft_ratatui has had a lot of changes recently, now supporting four different font rendering backends. The most embeddable and easiest to use one is embedded-graphics + embedded-graphics-unicode. This pull request bumps soft_ratatui version in cargo.toml and switches the windowed context to use the new backend. This also makes it now WASM compatible by default. In the future we should still somehow expose allowing the user to choose which font backend to use for soft_ratatui, but for now this is good enough.

As a bonus the rendering with this backend is pixel perfect since it uses a bitmap font.