### PR TITLE
chore: release v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.9.3](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.2...v0.9.3) - 2025-10-06
+
+### Other
+
+- Bump tracing-subscriber from 0.3.19 to 0.3.20 ([#66](https://github.com/cxreiff/bevy_ratatui/pull/66))
+- bump soft_ratatui ([#68](https://github.com/cxreiff/bevy_ratatui/pull/68))
+
 ## [0.9.2](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.1...v0.9.2) - 2025-05-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ checksum = "86f1275dfb4cfef4ffc90c3fa75408964864facf833acc932413d52aa5364ba4"
 
 [[package]]
 name = "bevy_ratatui"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "bevy",
  "bitflags 2.9.0",
@@ -3009,7 +3009,7 @@ dependencies = [
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rustc-hash 1.1.0",
  "thiserror 1.0.69",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_ratatui"
 description = "A Bevy plugin for building terminal user interfaces with Ratatui"
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/bevy_ratatui"


### PR DESCRIPTION



## 🤖 New release

* `bevy_ratatui`: 0.9.2 -> 0.9.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.3](https://github.com/cxreiff/bevy_ratatui/compare/v0.9.2...v0.9.3) - 2025-10-06

### Other

- Bump tracing-subscriber from 0.3.19 to 0.3.20 ([#66](https://github.com/cxreiff/bevy_ratatui/pull/66))
- bump soft_ratatui ([#68](https://github.com/cxreiff/bevy_ratatui/pull/68))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).